### PR TITLE
Force reload on form submission

### DIFF
--- a/public/js/judging.js
+++ b/public/js/judging.js
@@ -148,7 +148,7 @@ let submitEvaluation = (e) => {
     delete body[""];
     request("post", "/api/internal/judging/submit", body, (data) => {
         if (!data.error) {
-            window.setTimeout(() => window.location.reload(), 1000);
+            window.setTimeout(() => window.location.reload(true), 1000);
         } else {
             alert(data.error.message);
         }
@@ -160,7 +160,7 @@ let flagEntry = (id) => {
         let body = {entry_id: id};
         request("put", "/api/internal/entries/flag", body, (data) => {
             if (!data.error) {
-                window.setTimeout(() => window.location.reload(), 1000);
+                window.setTimeout(() => window.location.reload(true), 1000);
             } else {
                 alert(data.error.message);
             }


### PR DESCRIPTION
On some browsers, submitting the form doesn't actually change the displayed program because of caching.  This should ensure that doesn't happen.  This is a minor and niche change that shouldn't break anything.